### PR TITLE
Fix and update specs to suit RSpec 3 syntax.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem "rdf", :git => "git://github.com/ruby-rdf/rdf.git", :branch => "develop"
-
 group "development" do
   gem "rake"
-  gem "rdf-spec", :git => "git://github.com/ruby-rdf/rdf-spec.git", :branch => "develop"
   gem "dotenv"
 end

--- a/README
+++ b/README
@@ -69,6 +69,19 @@ follows:
 
     % wget https://github.com/ruby-rdf/rdf-sesame/tarball/master
 
+Tests
+-----
+
+In order to run test, you should use dotenv (which is set as a development dependency) and have a .env file with the following environment variables:
+```
+SESAME_URL=http://localhost:8080/openrdf-sesame # has to be an accessible openrdf-sesame server
+SESAME_REPOSITORY=integration_test # has to be the name of an existing repository on which we'll be doing the integration tests.
+```
+
+You can then run them with:
+
+    % bundle exec dotenv rake spec
+
 Mailing List
 ------------
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ follows:
 
     % wget https://github.com/ruby-rdf/rdf-sesame/tarball/master
 
+Tests
+-----
+
+In order to run test, you should use dotenv (which is set as a development dependency) and have a .env file with the following environment variables:
+```
+SESAME_URL=http://localhost:8080/openrdf-sesame # has to be an accessible openrdf-sesame server
+SESAME_REPOSITORY=integration_test # has to be the name of an existing repository on which we'll be doing the integration tests.
+```
+
+You can then run them with:
+
+    % bundle exec dotenv rake spec
+
 Mailing List
 ------------
 

--- a/lib/rdf/sesame/version.rb
+++ b/lib/rdf/sesame/version.rb
@@ -2,7 +2,7 @@ module RDF; module Sesame
   module VERSION
     MAJOR = 1
     MINOR = 1
-    TINY  = 0
+    TINY  = 1
     EXTRA = nil
 
     STRING = [MAJOR, MINOR, TINY, EXTRA].compact.join('.')

--- a/rdf-sesame.gemspec
+++ b/rdf-sesame.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'rdf',         '~> 1.1'
   gem.add_runtime_dependency     'addressable', '~> 2.3'
   gem.add_development_dependency 'yard' ,       '~> 0.8'
-  gem.add_development_dependency 'rspec',       '~> 2'
+  gem.add_development_dependency 'rspec',       '~> 3'
+  gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'rdf-spec',    '~> 1.1'
   gem.post_install_message       = nil
 end

--- a/spec/lib/rdf/sesame/connection_spec.rb
+++ b/spec/lib/rdf/sesame/connection_spec.rb
@@ -5,74 +5,78 @@ describe RDF::Sesame::Connection do
     @conn = RDF::Sesame::Connection.new(ENV['SESAME_URL'])
   end
 
+  subject do
+    @conn
+  end
+
   after :each do
     @conn.close
   end
 
-  let(:connection_url) {
-    uri = URI.parse(ENV['SESAME_URL'] || 'http://localhost:8080/openrdf-sesame')
-    uri.user = uri.password = nil
-    uri
-  }
+  let(:connection_url) do
+    URI.parse(ENV['SESAME_URL'] || 'http://localhost:8080/openrdf-sesame').tap do |uri|
+      uri.user = uri.password = nil
+    end
+  end
 
   it "supports opening a connection" do
-    @conn.should respond_to(:open)
-    @conn.should_not be_open
-    @conn.open
-    @conn.should be_open
+    expect(subject).to respond_to(:open)
+    expect(subject).not_to be_open
+    subject.open
+    expect(subject).to be_open
   end
 
   it "supports closing a connection manually" do
-    @conn.should respond_to(:close)
-    @conn.open
-    @conn.close
-    @conn.should_not be_open
+    expect(subject).to respond_to(:close)
+    subject.open
+    subject.close
+    expect(subject).not_to be_open
   end
 
   it "supports closing a connection automatically" do
-    @conn.should_not be_open
-    @conn.open do
-      @conn.should be_open
+    expect(subject).not_to be_open
+    subject.open do
+      expect(subject).to be_open
     end
-    @conn.should_not be_open
+    expect(subject).not_to be_open
   end
 
   it "supports HTTP GET requests" do
-    @conn.should respond_to(:get)
+    expect(subject).to respond_to(:get)
   end
 
   it "performs HTTP GET requests" do
-    response = @conn.get('protocol')
-    response.should be_a_kind_of(Net::HTTPSuccess)
-    response.body.should be_a String
+    response = subject.get('protocol')
+    expect(response).to be_a_kind_of(Net::HTTPSuccess)
+    expect(response.body).to be_a(String)
   end
 
   it "supports HTTP POST requests" do
-    @conn.should respond_to(:post)
+    expect(subject).to respond_to(:post)
   end
 
   it "performs HTTP POST requests"
 
   it "supports HTTP PUT requests" do
-    @conn.should respond_to(:put)
+    expect(subject).to respond_to(:put)
   end
 
   it "performs HTTP PUT requests"
 
   it "supports HTTP DELETE requests" do
-    @conn.should respond_to(:delete)
+    expect(subject).to respond_to(:delete)
   end
 
   it "performs HTTP DELETE requests"
 
   it "has a URI representation" do
-    @conn.should respond_to(:to_uri)
-    @conn.to_uri.should be_a(URI)
-    @conn.to_uri.should == connection_url
+    expect(subject).to respond_to(:to_uri)
+    expect(subject.to_uri).to be_a(URI)
+    expect(subject.to_uri).to eq connection_url
   end
 
   it "has a string representation" do
-    @conn.should respond_to(:to_s)
-    @conn.to_s.should == connection_url.to_s
+    expect(subject).to respond_to(:to_s)
+    expect(subject.to_s).to eq connection_url.to_s
   end
 end

--- a/spec/lib/rdf/sesame/repository_spec.rb
+++ b/spec/lib/rdf/sesame/repository_spec.rb
@@ -3,11 +3,11 @@ require 'rdf/ntriples'
 require 'rdf/spec/repository'
 
 describe RDF::Sesame::Repository do
-  let(:connection_url) {
-    uri = URI.parse(ENV['SESAME_URL'] || 'http://localhost:8080/openrdf-sesame')
-    uri.user = uri.password = nil
-    uri
-  }
+  let(:connection_url) do
+    URI.parse(ENV['SESAME_URL'] || 'http://localhost:8080/openrdf-sesame').tap do |uri|
+      uri.user = uri.password = nil
+    end
+  end
 
   context "when created" do
     it "requires exactly one argument" do
@@ -20,7 +20,7 @@ describe RDF::Sesame::Repository do
       expect { RDF::Sesame::Repository.new(url) }.not_to raise_error
 
       db = RDF::Sesame::Repository.new(url)
-      db.server.to_uri.to_s.should == connection_url.to_s
+      expect(db.server.to_uri.to_s).to eq connection_url.to_s
     end
 
     it "accepts a URI argument" do
@@ -28,7 +28,7 @@ describe RDF::Sesame::Repository do
       expect { RDF::Sesame::Repository.new(url) }.not_to raise_error
 
       db = RDF::Sesame::Repository.new(url)
-      db.server.to_uri.to_s.should == connection_url.to_s
+      expect(db.server.to_uri.to_s).to eq connection_url.to_s
     end
 
     it "accepts :server and :id" do
@@ -36,7 +36,7 @@ describe RDF::Sesame::Repository do
       expect { RDF::Sesame::Repository.new(options) }.not_to raise_error
 
       db = RDF::Sesame::Repository.new(options)
-      db.server.to_uri.to_s.should == connection_url.to_s
+      expect(db.server.to_uri.to_s).to eq connection_url.to_s
     end
 
     it "rejects :server without :id" do
@@ -60,15 +60,15 @@ describe RDF::Sesame::Repository do
     it "supports URL construction" do
       @server.each_repository do |repository|
         url = "#{connection_url}/repositories/#{repository.id}"
-        repository.should respond_to(:url, :uri)
-        repository.url.should == url.to_s
-        repository.url(:size).to_s.should == "#{url}/size"
+        expect(repository).to respond_to(:url, :uri)
+        expect(repository.url).to eq url.to_s
+        expect(repository.url(:size).to_s).to eq "#{url}/size"
       end
     end
 
     it "returns the size of each repository" do
       @server.each_repository do |repository|
-        repository.size.should be_a_kind_of(Numeric)
+        expect(repository.size).to be_a_kind_of(Numeric)
       end
     end
   end
@@ -102,8 +102,8 @@ describe RDF::Sesame::Repository do
       end
 
       it "returns a RDF::Query::Solutions" do
-        execution.should be_kind_of(RDF::Query::Solutions)
-        execution.should_not be_empty
+        expect(execution).to be_kind_of(RDF::Query::Solutions)
+        expect(execution).not_to be_empty
       end
     end
 
@@ -114,8 +114,8 @@ describe RDF::Sesame::Repository do
       end
 
       it "returns a RDF::NTriples::Reader" do
-        execution.should be_kind_of(RDF::NTriples::Reader)
-        execution.should have_statement(RDF::Statement.new(RDF::URI('http://ar.to/#self'), RDF::URI('http://xmlns.com/foaf/0.1/name'), RDF::Literal('Arto Bendiken')))
+        expect(execution).to be_kind_of(RDF::NTriples::Reader)
+        expect(execution).to have_statement(RDF::Statement.new(RDF::URI('http://ar.to/#self'), RDF::URI('http://xmlns.com/foaf/0.1/name'), RDF::Literal('Arto Bendiken')))
       end
     end
 
@@ -128,7 +128,7 @@ describe RDF::Sesame::Repository do
       end
 
       it "returns a RDF::NTriples::Reader" do
-        execution.should be_kind_of(RDF::NTriples::Reader)
+        expect(execution).to be_kind_of(RDF::NTriples::Reader)
       end
     end
   end

--- a/spec/lib/rdf/sesame/server_spec.rb
+++ b/spec/lib/rdf/sesame/server_spec.rb
@@ -1,75 +1,81 @@
 require 'spec_helper'
 
 describe RDF::Sesame::Server do
-  let(:connection_url) {
-    uri = URI.parse(ENV['SESAME_URL'] || 'http://localhost:8080/openrdf-sesame')
-    uri.user = uri.password = nil
-    uri
-  }
+  let(:connection_url) do
+    URI.parse(ENV['SESAME_URL'] || 'http://localhost:8080/openrdf-sesame').tap do |uri|
+      uri.user = uri.password = nil
+    end
+  end
+
+  subject do
+    @server
+  end
 
   it "supports URL construction" do
-    @server.should respond_to(:url, :uri)
-    @server.url.should == connection_url.to_s
-    @server.url(:protocol).should == "#{connection_url}/protocol"
-    @server.url('repositories/SYSTEM').should == "#{connection_url}/repositories/SYSTEM"
+    expect(subject).to respond_to(:url, :uri)
+    expect(subject.url).to eq connection_url.to_s
+    expect(subject.url(:protocol)).to eq "#{connection_url}/protocol"
+    expect(subject.url('repositories/SYSTEM')).to eq "#{connection_url}/repositories/SYSTEM"
   end
 
   it "has a URI representation" do
-    @server.should respond_to(:to_uri)
-    @server.to_uri.should be_a(URI)
-    @server.to_uri.should == connection_url
+    expect(subject).to respond_to(:to_uri)
+    expect(subject.to_uri).to be_a(URI)
+    expect(subject.to_uri).to eq connection_url
   end
 
   it "has a string representation" do
-    @server.should respond_to(:to_s)
-    @server.to_s.should == connection_url.to_s
+    expect(subject).to respond_to(:to_s)
+    expect(subject.to_s).to eq connection_url.to_s
   end
 
   it "returns the Sesame connection" do
-    @server.connection.should_not be_nil
-    @server.connection.should be_instance_of(RDF::Sesame::Connection)
+    expect(subject.connection).not_to be_nil
+    expect(subject.connection).to be_instance_of(RDF::Sesame::Connection)
   end
 
   it "returns the protocol version" do
-    @server.should respond_to(:protocol, :protocol_version)
-    @server.protocol.should be_a_kind_of(Numeric)
-    @server.protocol.should >= 4
+    expect(subject).to respond_to(:protocol, :protocol_version)
+    expect(subject.protocol).to be_a_kind_of(Numeric)
+    expect(subject.protocol).to be >= 4
   end
 
   it "returns available repositories" do
-    @server.should respond_to(:repositories)
-    @server.repositories.should be_a_kind_of(Enumerable)
-    @server.repositories.should be_instance_of(Hash)
-    @server.repositories.each do |identifier, repository|
-      identifier.should be_instance_of(String)
-      repository.should be_instance_of(RDF::Sesame::Repository)
+    expect(subject).to respond_to(:repositories)
+    expect(subject.repositories).to be_a_kind_of(Enumerable)
+    expect(subject.repositories).to be_instance_of(Hash)
+
+    subject.repositories.each do |identifier, repository|
+      expect(identifier).to be_instance_of(String)
+      expect(repository).to be_instance_of(RDF::Sesame::Repository)
     end
   end
 
   it "indicates whether a repository exists" do
-    @server.should respond_to(:has_repository?)
-    @server.has_repository?(:SYSTEM).should be_true
-    @server.has_repository?(:foobar).should be_false
+    expect(subject).to respond_to(:has_repository?)
+    expect(subject.has_repository?(:SYSTEM)).to be true
+    expect(subject.has_repository?(:foobar)).to be false
   end
 
   it "returns existing repositories" do
-    @server.should respond_to(:repository, :[])
-    repository = @server.repository(:SYSTEM)
-    repository.should_not be_nil
-    repository.should be_instance_of(RDF::Sesame::Repository)
+    expect(subject).to respond_to(:repository, :[])
+    repository = subject.repository(:SYSTEM)
+    expect(repository).not_to be_nil
+    expect(repository).to be_instance_of(RDF::Sesame::Repository)
   end
 
   it "does not return nonexistent repositories" do
-    lambda { @server.repository(:foobar) }.should_not raise_error
-    repository = @server.repository(:foobar)
-    repository.should be_nil
+    expect { subject.repository(:foobar) }.not_to raise_error
+    repository = subject.repository(:foobar)
+    expect(repository).to be_nil
   end
 
   it "supports enumerating repositories" do
-    @server.should respond_to(:each_repository, :each)
-    @server.each_repository.should be_a(Enumerator)
-    @server.each_repository do |repository|
-      repository.should be_instance_of(RDF::Sesame::Repository)
+    expect(subject).to respond_to(:each_repository, :each)
+    expect(subject.each_repository).to be_a(Enumerator)
+
+    subject.each_repository do |repository|
+      expect(repository).to be_instance_of(RDF::Sesame::Repository)
     end
   end
 end

--- a/spec/lib/rdf/sesame/version_spec.rb
+++ b/spec/lib/rdf/sesame/version_spec.rb
@@ -1,8 +1,15 @@
 require 'spec_helper'
 
 describe 'RDF::Sesame::VERSION' do
+  let(:version_file_path) do
+    File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'VERSION')
+  end
+
+  let(:version) do
+    File.read(version_file_path).chomp
+  end
+
   it "should match the VERSION file" do
-    version_file_path = File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'VERSION')
-    RDF::Sesame::VERSION.to_s.should == File.read(version_file_path).chomp
+    expect(RDF::Sesame::VERSION.to_s).to eq version
   end
 end


### PR DESCRIPTION
In this PR, a small issue about the version number is fixed so the version number in the VERSION file is the same as RDF::Sesame::VERSION. 

Moreover, the tests were updated in general to make them suit the new RSpec 3 syntax instead of the old deprecated one.