### PR TITLE
Use the right method to get graph_names

### DIFF
--- a/spec/lib/rdf/sesame/repository_spec.rb
+++ b/spec/lib/rdf/sesame/repository_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'rdf/ntriples'
-#require 'rdf/spec/repository'
+require 'rdf/spec/repository'
 
 describe RDF::Sesame::Repository do
   let(:connection_url) do
@@ -79,7 +79,11 @@ describe RDF::Sesame::Repository do
     end
 
     # @see lib/rdf/spec/repository.rb in rdf-spec
-    # include RDF_Repository
+    # it_behaves_like 'an RDF::Repository' do
+    #   let(:repository) do
+    #     @repository
+    #   end
+    # end
   end
 
   describe "#sparql_query" do


### PR DESCRIPTION
Use the right method to get graph_names
Use RDF::Spec shared example

Following the usage of RDF 2.0, instead of the #contexts method, we should now have the #graph_names method on Repositories. This inconsistent change induced the issue #13.

The RDF::Sesame::Repository API changed and the #contexts method became #graph_names, as it should have been to follow the new RDF 2.0 RDF::Repository API.

I added the inclusion of shared RDF 2.0 Repository specs.

K